### PR TITLE
Additional fixes for E2 Helm chart

### DIFF
--- a/e2t/templates/NOTES.txt
+++ b/e2t/templates/NOTES.txt
@@ -4,7 +4,7 @@
 
 # Services ####################################
 
-{{ if .Values.e2tsctp.enabled -}}
+{{ if .Values.e2tsctp.sctpService.enabled -}}
 ## E2 Termination SCTP
 {{ if contains "NodePort" .Values.e2tsctp.sctpService.type }}
 Get the E2 Termination SCTP details by running these commands:

--- a/e2t/templates/_helpers.tpl
+++ b/e2t/templates/_helpers.tpl
@@ -44,6 +44,7 @@ drax/instanceId: "{{ tpl .Values.bootstrapId . }}"
 Sctp labels
 */}}
 {{- define "e2t.sctp.labels" -}}
+{{ include "e2t.labels" . }}
 {{ include "e2t.sctp.selectorLabels" . }}
 {{- end }}
 
@@ -51,6 +52,7 @@ Sctp labels
 E2ap labels
 */}}
 {{- define "e2t.e2ap.labels" -}}
+{{ include "e2t.labels" . }}
 {{ include "e2t.e2ap.selectorLabels" . }}
 {{- end }}
 
@@ -58,6 +60,7 @@ E2ap labels
 Kpm labels
 */}}
 {{- define "e2t.kpm.labels" -}}
+{{ include "e2t.labels" . }}
 {{ include "e2t.kpm.selectorLabels" . }}
 {{- end }}
 

--- a/e2t/templates/deployment-e2t-sctp.yaml
+++ b/e2t/templates/deployment-e2t-sctp.yaml
@@ -54,14 +54,6 @@ spec:
             - name: {{ tpl .Values.e2tsctp.sctpService.name . }}
               containerPort: {{ .Values.e2tsctp.sctpService.port}}
               protocol: {{ .Values.e2tsctp.sctpService.protocol }}
-#          livenessProbe:
-#            httpGet:
-#              path: /
-#              port: http
-#          readinessProbe:
-#            httpGet:
-#              path: /
-#              port: http
           volumeMounts:
             - name: {{ include "e2t.fullname" . }}-bootstrap
               mountPath: {{ .Values.e2tsctp.bootstrapFile }}

--- a/e2t/templates/deployment-e2t-sctp.yaml
+++ b/e2t/templates/deployment-e2t-sctp.yaml
@@ -5,9 +5,7 @@ metadata:
   labels:
     {{- include "e2t.sctp.labels"  . | nindent 4 }}
 spec:
-{{- if not .Values.e2tsctp.autoscaling.enabled }}
   replicas: {{ .Values.e2tsctp.replicaCount }}
-{{- end }}
   selector:
     matchLabels:
        {{- include "e2t.sctp.selectorLabels" . | nindent 6 }}

--- a/e2t/templates/deployment-e2t-sctp.yaml
+++ b/e2t/templates/deployment-e2t-sctp.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "e2t.fullname" . }}-scpt
+  name: {{ include "e2t.fullname" . }}-sctp
   labels:
     {{- include "e2t.sctp.labels"  . | nindent 4 }}
 spec:

--- a/e2t/templates/deployment-e2t-sctp.yaml
+++ b/e2t/templates/deployment-e2t-sctp.yaml
@@ -33,15 +33,6 @@ spec:
             {{- toYaml .Values.e2tsctp.securityContext | nindent 12 }}
           image: "{{ .Values.e2tsctp.image.repository }}:{{ tpl .Values.e2tsctp.image.tag . | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.e2tsctp.image.pullPolicy }}
-          {{ if .Values.e2tsctp.developerMode.enabled }}
-          command:
-            - sh
-            - "-c"
-            - |
-              /bin/bash <<'EOF'
-              while true; do sleep 30; done;
-              EOF
-          {{ else }}
           command:
             - sh
             - "-c"
@@ -49,7 +40,6 @@ spec:
               /bin/sh <<'EOF'
               {{ .Values.e2tsctp.cmd }} {{- if .Values.e2tsctp.args }}{{ range .Values.e2tsctp.args }} {{ .name }} {{ .value }}{{ end }}{{- end }}
               EOF
-          {{ end }}
           env: 
             - name: NATS_SERVICE_URL
               value: nats://{{ tpl .Values.natsHostname . }}:{{ tpl .Values.natsPort . }}
@@ -78,10 +68,6 @@ spec:
             - name: {{ include "e2t.fullname" . }}-bootstrap
               mountPath: {{ .Values.e2tsctp.bootstrapFile }}
               subPath: "bootstrap.txt"
-            {{ if and (.Values.e2tsctp.developerMode.enabled) (.Values.e2tsctp.developerMode.hostPath) }}
-            - name: dev-work-dir
-              mountPath: /home/accelleran/5G/dev/
-            {{ end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           lifecycle:
@@ -109,9 +95,3 @@ spec:
         - name: {{ include "e2t.fullname" . }}-bootstrap
           configMap:
             name: {{ include "e2t.fullname" . }}-bootstrap
-
-        {{ if and (.Values.e2tsctp.developerMode.enabled) (.Values.e2tsctp.developerMode.hostPath) }}
-        - name: dev-work-dir
-          hostPath:
-            path: {{ .Values.e2tsctp.developerMode.hostPath }}
-        {{ end }}

--- a/e2t/templates/deployment-e2t-sm-kpm.yaml
+++ b/e2t/templates/deployment-e2t-sm-kpm.yaml
@@ -33,15 +33,6 @@ spec:
             {{- toYaml .Values.e2smkpm.securityContext | nindent 12 }}
           image: "{{ .Values.e2smkpm.image.repository }}:{{ tpl .Values.e2smkpm.image.tag . | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.e2smkpm.image.pullPolicy }}
-          {{ if .Values.e2smkpm.developerMode.enabled }}
-          command:
-            - sh
-            - "-c"
-            - |
-              /bin/bash <<'EOF'
-              while true; do sleep 30; done;
-              EOF
-          {{ else }}
           command:
             - sh
             - "-c"
@@ -49,7 +40,6 @@ spec:
               /bin/sh <<'EOF'
               {{ .Values.e2smkpm.cmd }} {{- if .Values.e2smkpm.args }}{{ range .Values.e2smkpm.args }} {{ .name }} {{ .value }}{{ end }}{{- end }}
               EOF
-          {{ end }}
           env:
             - name: NATS_SERVICE_URL
               value: nats://{{ tpl .Values.natsHostname . }}:{{ tpl .Values.natsPort . }}
@@ -76,10 +66,6 @@ spec:
             - name: {{ include "e2t.fullname" . }}-bootstrap
               mountPath: {{ .Values.e2smkpm.bootstrapFile }}
               subPath: "bootstrap.txt"
-            {{ if and (.Values.e2smkpm.developerMode.enabled) (.Values.e2smkpm.developerMode.hostPath) }}
-            - name: dev-work-dir
-              mountPath: /home/accelleran/5G/dev/
-            {{ end }}
           resources:
             {{- toYaml .Values.e2smkpm.resources | nindent 12 }}
           lifecycle:
@@ -107,9 +93,3 @@ spec:
         - name: {{ include "e2t.fullname" . }}-bootstrap
           configMap:
             name: {{ include "e2t.fullname" . }}-bootstrap
-
-        {{ if and (.Values.e2smkpm.developerMode.enabled) (.Values.e2smkpm.developerMode.hostPath) }}
-        - name: dev-work-dir
-          hostPath:
-            path: {{ .Values.e2smkpm.developerMode.hostPath }}
-        {{ end }}

--- a/e2t/templates/deployment-e2t-sm-kpm.yaml
+++ b/e2t/templates/deployment-e2t-sm-kpm.yaml
@@ -48,14 +48,6 @@ spec:
             {{- if .Values.e2smkpm.extraEnvs }}
             {{ toYaml .Values.e2smkpm.extraEnvs | nindent 12 }}
             {{- end }}
-#          livenessProbe:
-#            httpGet:
-#              path: /
-#              port: http
-#          readinessProbe:
-#            httpGet:
-#              path: /
-#              port: http
           volumeMounts:
             - name: {{ include "e2t.fullname" . }}-bootstrap
               mountPath: {{ .Values.e2smkpm.bootstrapFile }}

--- a/e2t/templates/deployment-e2t-sm-kpm.yaml
+++ b/e2t/templates/deployment-e2t-sm-kpm.yaml
@@ -5,9 +5,7 @@ metadata:
   labels:
     {{- include "e2t.kpm.labels" . | nindent 4 }}
 spec:
-{{- if not .Values.e2smkpm.autoscaling.enabled }}
   replicas: {{ .Values.e2smkpm.replicaCount }}
-{{- end }}
   selector:
     matchLabels:
       {{- include "e2t.kpm.selectorLabels" . | nindent 6 }}
@@ -50,10 +48,6 @@ spec:
             {{- if .Values.e2smkpm.extraEnvs }}
             {{ toYaml .Values.e2smkpm.extraEnvs | nindent 12 }}
             {{- end }}
-#          ports:
-#            - name: {{ tpl .Values.e2smkpm.service.name . }}
-#              containerPort: {{ .Values.e2smkpm.service.port}}
-#              protocol: {{ .Values.e2smkpm.service.protocol }}
 #          livenessProbe:
 #            httpGet:
 #              path: /

--- a/e2t/templates/deployment-e2t-sm-kpm.yaml
+++ b/e2t/templates/deployment-e2t-sm-kpm.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "e2t.kpm.labels" . | nindent 4 }}
 spec:
 {{- if not .Values.e2smkpm.autoscaling.enabled }}
-  replicas: {{ .Values.e2smkpm.replicas }}
+  replicas: {{ .Values.e2smkpm.replicaCount }}
 {{- end }}
   selector:
     matchLabels:

--- a/e2t/templates/service-e2t-sctp.yaml
+++ b/e2t/templates/service-e2t-sctp.yaml
@@ -7,19 +7,19 @@ metadata:
     {{- include "e2t.sctp.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.e2tsctp.sctpService.type }}
-  {{ if .Values.e2tsctp.sctpService.externalTrafficPolicy }}
+  {{- if .Values.e2tsctp.sctpService.externalTrafficPolicy }}
   externalTrafficPolicy: {{ tpl .Values.e2tsctp.sctpService.externalTrafficPolicy . }}
-  {{ end }}
+  {{- end }}
   ports:
     - port: {{ .Values.e2tsctp.sctpService.port}}
       protocol: {{ .Values.e2tsctp.sctpService.protocol }}
       name: {{ tpl .Values.e2tsctp.sctpService.name . }}
-      {{ if contains "NodePort" .Values.e2tsctp.sctpService.type }}
+      {{- if contains "NodePort" .Values.e2tsctp.sctpService.type }}
       nodePort: {{ .Values.e2tsctp.sctpService.nodePort }}
-      {{ end }}
-  {{ if .Values.e2tsctp.sctpService.loadBalancerIP }}
+      {{- end }}
+  {{- if .Values.e2tsctp.sctpService.loadBalancerIP }}
   loadBalancerIP: {{ tpl .Values.e2tsctp.sctpService.loadBalancerIP . }}
-  {{ end }}
+  {{- end }}
   selector:
     {{- include "e2t.sctp.selectorLabels" . | nindent 4 }}
 {{- end -}}

--- a/e2t/templates/statefulset-e2tap.yaml
+++ b/e2t/templates/statefulset-e2tap.yaml
@@ -34,17 +34,6 @@ spec:
             {{- toYaml .Values.e2tap.securityContext | nindent 12 }}
           image: "{{ .Values.e2tap.image.repository }}:{{ tpl .Values.e2tap.image.tag . | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.e2tap.image.pullPolicy }}
-          {{ if .Values.e2tap.developerMode.enabled }}
-          command:
-            - sh
-            - "-c"
-            - |
-              /bin/bash <<'EOF'
-              echo "export __APPID=e2-ap-${HOSTNAME##*-}" > /home/accelleran/5G/dev/environment.sh
-              chmod +x /home/accelleran/5G/dev/environment.sh
-              while true; do sleep 30; done;
-              EOF
-          {{ else }}
           command:
             - sh
             - "-c"
@@ -53,7 +42,6 @@ spec:
               echo e2-ap-${HOSTNAME##*-}
               __APPID=e2-ap-${HOSTNAME##*-} {{ .Values.e2tap.cmd }} {{- if .Values.e2tap.args }}{{ range .Values.e2tap.args }} {{ .name }} {{ .value }}{{ end }}{{- end }}
               EOF
-          {{ end }}
           env:
             - name: NATS_SERVICE_URL
               value: nats://{{ tpl .Values.natsHostname . }}:{{ tpl .Values.natsPort . }}
@@ -82,10 +70,6 @@ spec:
             - name: {{ include "e2t.fullname" . }}-bootstrap
               mountPath: {{ .Values.e2tap.bootstrapFile }}
               subPath: "bootstrap.txt"
-            {{ if and (.Values.e2tap.developerMode.enabled) (.Values.e2tap.developerMode.hostPath) }}
-            - name: dev-work-dir
-              mountPath: /home/accelleran/5G/dev/
-            {{ end }}
           resources:
             {{- toYaml .Values.e2tap.resources | nindent 12 }}
           lifecycle:
@@ -110,13 +94,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-
         - name: {{ include "e2t.fullname" . }}-bootstrap
           configMap:
             name: {{ include "e2t.fullname" . }}-bootstrap
-
-        {{ if and (.Values.e2tap.developerMode.enabled) (.Values.e2tap.developerMode.hostPath) }}
-        - name: dev-work-dir
-          hostPath:
-            path: {{ .Values.e2tap.developerMode.hostPath }}
-        {{ end }}

--- a/e2t/templates/statefulset-e2tap.yaml
+++ b/e2t/templates/statefulset-e2tap.yaml
@@ -6,9 +6,7 @@ metadata:
     {{- include "e2t.e2ap.labels" . | nindent 4 }}
 spec:
   serviceName: {{ include "e2t.fullname" . }}-service
-  {{- if not .Values.e2tap.autoscaling.enabled }}
   replicas: {{ tpl .Values.e2tap.numOfE2Nodes . }}
-  {{- end }}
   selector:
     matchLabels:
       {{- include "e2t.e2ap.selectorLabels" . | nindent 6 }}
@@ -54,10 +52,6 @@ spec:
             {{- if .Values.e2tap.extraEnvs }}
             {{ toYaml .Values.e2tap.extraEnvs | nindent 12 }}
             {{- end }}
-#          ports:
-#            - name: {{ tpl .Values.e2tap.service.name . }}
-#              containerPort: {{ .Values.e2tap.service.port}}
-#              protocol: {{ .Values.e2tap.service.protocol }}
 #          livenessProbe:
 #            httpGet:
 #              path: /

--- a/e2t/templates/statefulset-e2tap.yaml
+++ b/e2t/templates/statefulset-e2tap.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "e2t.fullname" . }}
+  name: {{ include "e2t.fullname" . }}-e2tap
   labels:
     {{- include "e2t.e2ap.labels" . | nindent 4 }}
 spec:

--- a/e2t/templates/statefulset-e2tap.yaml
+++ b/e2t/templates/statefulset-e2tap.yaml
@@ -52,14 +52,6 @@ spec:
             {{- if .Values.e2tap.extraEnvs }}
             {{ toYaml .Values.e2tap.extraEnvs | nindent 12 }}
             {{- end }}
-#          livenessProbe:
-#            httpGet:
-#              path: /
-#              port: http
-#          readinessProbe:
-#            httpGet:
-#              path: /
-#              port: http
           volumeMounts:
             - name: {{ include "e2t.fullname" . }}-bootstrap
               mountPath: {{ .Values.e2tap.bootstrapFile }}

--- a/e2t/values.yaml
+++ b/e2t/values.yaml
@@ -46,7 +46,8 @@ redisConfig:
 #   Example:
 #
 draxNodeSelectorEnabled: "false"
-draxName: "main"
+draxNodeSelector:
+  draxName: ""
 
 # Jaeger settings
 #   Description:  Sets the DNS hostname where the Jaeger agent is located

--- a/e2t/values.yaml
+++ b/e2t/values.yaml
@@ -77,7 +77,7 @@ e2tsctp:
 
   enabled: true
 
-  replica: 1
+  replicaCount: 1
 
   image:
     repository: accelleran/e2sctpappl
@@ -262,7 +262,7 @@ e2tap:
 
 e2smkpm:
 
-  replicas: 1
+  replicaCount: 1
 
   image:
     repository: accelleran/e2smkpmappl

--- a/e2t/values.yaml
+++ b/e2t/values.yaml
@@ -16,14 +16,6 @@ natsHostname: "10.55.1.2"
 natsPort: "31100"
 
 
-# Version of the 5G applications
-#   Description: This is the version of the 5G applications
-#                in DockerHub.
-#   Value type: string
-#
-tag: "master-c9d13a75"
-
-
 # Redis settings
 #   Description: Certain application need to be able to reach
 #                Redis. Here we configure the Redis hostname
@@ -70,6 +62,7 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+
 nameOverride: ""
 fullnameOverride: ""
 
@@ -89,7 +82,6 @@ e2tsctp:
     - name: accelleran-secret
 
   # Application Settings
-  # cmd: "__APPNAME=amfController ./amfControllerAppl.exe"
   cmd: "./sctpE2apAppl.exe"
 
   args: []
@@ -130,19 +122,6 @@ e2tsctp:
     nodePort: 31900
     # externalTrafficPolicy: "Local"
 
-  ingress:
-    enabled: false
-    annotations: {}
-      # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
-    hosts:
-      - host: chart-example.local
-        paths: []
-    tls: []
-    #  - secretName: chart-example-tls
-    #    hosts:
-    #      - chart-example.local
-
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
@@ -154,13 +133,6 @@ e2tsctp:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
-
-  autoscaling:
-    enabled: false
-    minReplicas: 1
-    maxReplicas: 100
-    targetCPUUtilizationPercentage: 80
-    # targetMemoryUtilizationPercentage: 80
 
   nodeSelector: {}
 
@@ -183,7 +155,6 @@ e2tap:
     - name: accelleran-secret
 
   # Application Settings
-  # cmd: "__APPNAME=amfController ./amfControllerAppl.exe"
   cmd: "./e2ApAppl.exe"
 
   args: []
@@ -212,29 +183,6 @@ e2tap:
     runAsUser: 0
     privileged: true
 
-  service:
-    enabled: false
-    name: "e2-service"
-    type: NodePort
-    protocol: SCTP
-    port: 80
-    # loadBalancerIP:
-    # nodePort:
-    # externalTrafficPolicy: "Local"
-
-  ingress:
-    enabled: false
-    annotations: {}
-      # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
-    hosts:
-      - host: chart-example.local
-        paths: []
-    tls: []
-    #  - secretName: chart-example-tls
-    #    hosts:
-    #      - chart-example.local
-
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
@@ -246,13 +194,6 @@ e2tap:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
-
-  autoscaling:
-    enabled: false
-    minReplicas: 1
-    maxReplicas: 100
-    targetCPUUtilizationPercentage: 80
-    # targetMemoryUtilizationPercentage: 80
 
   nodeSelector: {}
 
@@ -274,7 +215,6 @@ e2smkpm:
     - name: accelleran-secret
 
   # Application Settings
-  # cmd: "__APPNAME=amfController ./amfControllerAppl.exe"
   cmd: "./e2SmKpmAppl.exe"
 
   args: []
@@ -305,29 +245,6 @@ e2smkpm:
     runAsUser: 0
     privileged: true
 
-  service:
-    enabled: false
-    name: "e2-kpm-sm"
-    type: NodePort
-    protocol: SCTP
-    port: 80
-    # loadBalancerIP:
-    # nodePort:
-    # externalTrafficPolicy: "Local"
-
-  ingress:
-    enabled: false
-    annotations: {}
-      # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
-    hosts:
-      - host: chart-example.local
-        paths: []
-    tls: []
-    #  - secretName: chart-example-tls
-    #    hosts:
-    #      - chart-example.local
-
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
@@ -339,13 +256,6 @@ e2smkpm:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
-
-  autoscaling:
-    enabled: false
-    minReplicas: 1
-    maxReplicas: 100
-    targetCPUUtilizationPercentage: 80
-    # targetMemoryUtilizationPercentage: 80
 
   nodeSelector: {}
 

--- a/e2t/values.yaml
+++ b/e2t/values.yaml
@@ -168,10 +168,6 @@ e2tsctp:
 
   affinity: {}
 
-  developerMode:
-    enabled: false
-    hostPath: ""
-
 e2tap:
   enabled: true
 
@@ -263,10 +259,6 @@ e2tap:
   tolerations: []
 
   affinity: {}
-
-  developerMode:
-    enabled: false
-    hostPath: ""
 
 e2smkpm:
 
@@ -360,7 +352,3 @@ e2smkpm:
   tolerations: []
 
   affinity: {}
-
-  developerMode:
-    enabled: false
-    hostPath: ""

--- a/e2t/values.yaml
+++ b/e2t/values.yaml
@@ -116,11 +116,11 @@ e2tsctp:
   sctpService:
     enabled: true
     name: "e2-sctp"
-    type:  LoadBalancer
+    type:  NodePort
     protocol: SCTP
     port: 38482
-    # loadBalancerIP:
     nodePort: 31900
+    # loadBalancerIP:
     # externalTrafficPolicy: "Local"
 
   resources: {}

--- a/e2t/values.yaml
+++ b/e2t/values.yaml
@@ -69,8 +69,6 @@ fullnameOverride: ""
 
 e2tsctp:
 
-  enabled: true
-
   replicaCount: 1
 
   image:
@@ -142,7 +140,6 @@ e2tsctp:
   affinity: {}
 
 e2tap:
-  enabled: true
 
   numOfE2Nodes: "5"
 


### PR DESCRIPTION
Most of these changes relate to things I've spotted in the values file - either values that aren't used/needed any more, or differences between how values were defined from how they were being used (e.g. `draxNodeSelector`).

One change worth explicit mention is the labels one - I updated all of the `e2t.***.labels` to include the base `e2t.labels`. Without this, most of the K8S Resources we created didn't have most of the labels we defined in `e2t.labels`.